### PR TITLE
fix auto call next

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ class PromiseRouter {
           const rv = handler(req, res, next);
 
           // Check if promise, if yes, execute then.
-          if (isPromise(rv))
+          if (isPromise(rv)) {
             rv
               .then(data => {
                 if (opt_isLast && data)
@@ -84,6 +84,9 @@ class PromiseRouter {
                   next();
               })
               .catch(next);
+          } else {
+            next();
+          }
         } catch (err) {
           next(err);
         }


### PR DESCRIPTION
Fix when express middleware only function, it will not auto call next

I try to use this package. It's great. Reduce my repetition code. I no need to always use try catch in my async middleware or wrap my every middleware. Only single wrap on my express router. With auto call next is great too.

But i found issue when my middleware is not promise or async function. When it is just plain function, auto call next is doesn't work. I have to call next manually to move to the next middleware. So i modify your code, if it isn't promise, call next.

Thanks