### PR TITLE
Headers sent bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ class PromiseRouter {
           if (isPromise(rv)) {
             rv
               .then(data => {
-                if (opt_isLast && data)
+                if (opt_isLast && data && !res.headersSent)
                   res.json(data);
                 else if (!opt_isLast)
                   next();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-router-wrapper",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Express Router with Sync, Promise and Async-Await Support",
   "main": "index.js",
   "repository": "https://github.com/anonrig/express-router-wrapper",


### PR DESCRIPTION
- Calling res.json automatically even though the developer called it causes "Headers already sent" bug.